### PR TITLE
feat: implement support for block children paging

### DIFF
--- a/src/NotionApiFacade.ts
+++ b/src/NotionApiFacade.ts
@@ -49,10 +49,10 @@ export class NotionApiFacade {
             ...query,
             start_cursor: next_cursor || undefined,
           })
-      ); 
+      );
 
       results.push(...response.results);
-      
+
       next_cursor = response.next_cursor;
     } while (next_cursor);
 
@@ -66,20 +66,25 @@ export class NotionApiFacade {
   }
 
   async listBlockChildren(blockId: string) {
-    const result = await this.withRetry(
-      async () =>
-        await this.client.blocks.children.list({
-          block_id: blockId,
-        })
-    ); // todo: paging here?
+    const results = [];
 
-    if (result.next_cursor) {
-      throw new Error(
-        `Paging not implemented, block ${blockId} has more children than returned in a single request`
+    let next_cursor: string | null = null;
+
+    do {
+      const response = await this.withRetry(
+        async () =>
+          await this.client.blocks.children.list({
+            block_id: blockId,
+            start_cursor: next_cursor || undefined,
+          })
       );
-    }
 
-    return result;
+      results.push(...response.results);
+
+      next_cursor = response.next_cursor;
+    } while (next_cursor);
+
+    return results;
   }
 
   printStats() {

--- a/src/RecursiveBodyRenderer.ts
+++ b/src/RecursiveBodyRenderer.ts
@@ -20,8 +20,7 @@ export class RecursiveBodyRenderer {
 
     const childs = await this.publicApi.listBlockChildren(page.id);
 
-    // todo: paging
-    const renderChilds = childs.results.map(
+    const renderChilds = childs.map(
       async (x) => await this.renderBlock(x, "", context)
     );
     const blocks = await Promise.all(renderChilds);
@@ -47,7 +46,7 @@ export class RecursiveBodyRenderer {
     // blocks, see https://developers.notion.com/reference/retrieve-a-block
     // "If a block contains the key has_children: true, use the Retrieve block children endpoint to get the list of children"
     const children = block.has_children
-      ? (await this.publicApi.listBlockChildren(block.id)).results
+      ? (await this.publicApi.listBlockChildren(block.id))
       : [];
 
     const childIndent = indent + " ".repeat(parentBlock?.childIndent || 0);


### PR DESCRIPTION
this hasn't been a problem so far since blocks usually don't have more than 100 children. Fix this potential issue nonetheless while we're at it.