### PR TITLE
Add support for people property

### DIFF
--- a/src/PropertiesParser.ts
+++ b/src/PropertiesParser.ts
@@ -109,9 +109,10 @@ export class PropertiesParser {
         return value.last_edited_time;
       case "last_edited_by":
         return value.last_edited_by.name;
+      case "people":
+        return value.people.map((person) => person.name).join(", ");
       case "formula":
       case "rollup":
-      case "people":
       case "files":
       case "checkbox":
         const notSupported = "unsupported property type: " + value.type;


### PR DESCRIPTION
<img width="294" alt="Screenshot 2024-01-04 at 21 26 28" src="https://github.com/meshcloud/notion-markdown-cms/assets/21036432/53c4c84d-9de7-4323-8fdc-f8a2e2109441">

Through this PR the property `people` (or _persons_ in the application) who are still not supported will become available. If there is more than one person, it will be combined and added with a comma and space.

e.g. **John Doe** and **Jane Doe**, the result will be `John Doe, Jane Doe`
